### PR TITLE
Made floor plan card double clickable to open

### DIFF
--- a/floor-plan/src/app/editor/page.tsx
+++ b/floor-plan/src/app/editor/page.tsx
@@ -218,7 +218,7 @@ export default function Editor() {
 				className="lutronLogo"
 				onClick={() => router.push('/home')}
 				src="https://umslogin.lutron.com/Content/Dynamic/Default/Images/logo-lutron-blue.svg"
-				alt="Lutron Electronics Logo"
+				alt="Lutron Electronics Logo - click to go back to home page"
 			/>
 			<EditorToolbar
 				exportCanvasAsPDF={exportCanvasAsPDF}

--- a/floor-plan/src/app/home/page.tsx
+++ b/floor-plan/src/app/home/page.tsx
@@ -439,7 +439,7 @@ export default function Home() {
 				*/}
 					<div className={styles.fileList}>
 						{floorPlans.map((file: FloorPlanDocument) => (
-							<div key={file.id} className={styles.fileItem} onMouseLeave={handleMouseLeave}>
+							<div key={file.id} className={styles.fileItem} onDoubleClick={() => openFloorplan(file.pdfURL, file.id, file.name || 'Untitled')} onMouseLeave={handleMouseLeave}>
 								<div className={styles.fileItemTopRow}>
 									<img
 										src={thumbnails[file.id] || 'default-thumbnail.png'} // Display thumbnail or fallback
@@ -483,7 +483,6 @@ export default function Home() {
 										</>
 									) : (
 										<div className={styles.popupMenu} onMouseLeave={handleMouseLeave}>
-											<button onClick={() => openFloorplan(file.pdfURL, file.id, file.name || 'Untitled')}>Open</button>
 											<button onClick={() => handleDelete(file.id)}>Delete</button>
 											<button onClick={() => startRenaming(file.id!, file.name)}>Rename</button>
 										</div>


### PR DESCRIPTION
- User can now open floor plans by double clicking on them
- Removed open option from floor plan three dot menu pop up
- Editor page: Lutron logo updated with more descriptive alt for accessibility concerns